### PR TITLE
Update .travis to fix codecov badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: go
 
-go: 1.12.x
+go: 1.13.x
 
 before_install:
-- go get -t -v ./...
+- go mod download
 
 script:
-- go test -race -coverprofile=coverage.txt -covermode=atomic
+- go test -race -cover -coverprofile=coverage.txt -covermode=atomic ./...
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
The go test command was missing `-cov` and the path to all the files. 
Also changed to go 1.13 to download dependencies with `mod download` 