### PR TITLE
fix: invalid Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.15 as build
+FROM golang:1.17 as build
 WORKDIR /app
 ADD . .
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -mod=vendor -ldflags="-w -s" -mod vendor
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-w -s"
 
 FROM alpine
 COPY --from=build /app/gocity /bin/gocity


### PR DESCRIPTION
- golang 1.15 is out-of-date for package embed
- vendor mod is out-of-date